### PR TITLE
Make the url of git repository access without a trouble

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,6 @@
 # Copyright(c) 2015-2018 ACCESS CO., LTD. All rights reserved.
 
-antikythera_dep = {:antikythera, [git: "git@github.com:access-company/antikythera.git", ref: "f82ba97b1b2cfde87e85308d76766f84a34f8984"]}
+antikythera_dep = {:antikythera, [github: "access-company/antikythera", ref: "f82ba97b1b2cfde87e85308d76766f84a34f8984"]}
 
 try do
   parent_dir = Path.expand("..", __DIR__)


### PR DESCRIPTION
To avoid a following error on my machine:

```
antikythera_instance_example% mix deps.get
* Getting antikythera (git@github.com:access-company/antikythera.git)
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
** (Mix) Command "git --git-dir=.git fetch --force --quiet --progress" failed
```